### PR TITLE
fix: guard menu hover when no secondary items

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -72,9 +72,8 @@ document.addEventListener("DOMContentLoaded", () => {
         .querySelector(".menu__secondary-list")
         .classList.add(MENU_SHOW_CLASS);
 
-    [...parentList.querySelectorAll(".secondary-list__item")][0].classList.add(
-      "is-hovered"
-    );
+    const firstItem = parentList.querySelector(".secondary-list__item");
+    firstItem && firstItem.classList.add(HOVER_CLASS);
   };
 
   const setVisibleMenuByPrimaryBlock = selector => {


### PR DESCRIPTION
## Summary
- prevent menu hover crash when a primary link has no secondary items by checking for first item before adding hover class

## Testing
- `node --check js/menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68a20394db54832b90b0153ee8a24839