### PR TITLE
feat: add mobile accordion to what-we-do section

### DIFF
--- a/css/wwd-mobile.css
+++ b/css/wwd-mobile.css
@@ -1,0 +1,25 @@
+@media (max-width: 699px) {
+  .wwd-slide__list-item {
+    position: relative;
+  }
+  .wwd-slide__list-item > span.list__item:after {
+    content: "";
+    position: absolute;
+    right: 0;
+    top: 50%;
+    width: 8px;
+    height: 8px;
+    border-right: 1px solid currentColor;
+    border-bottom: 1px solid currentColor;
+    transform: translateY(-50%) rotate(45deg);
+    transition: transform 0.3s;
+  }
+  .wwd-slide__list-item.is-active > span.list__item:after {
+    transform: translateY(-50%) rotate(-135deg);
+  }
+  .wwd-slide__text {
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height 0.3s ease;
+  }
+}

--- a/js/wwd-mobile.js
+++ b/js/wwd-mobile.js
@@ -1,0 +1,30 @@
+window.addEventListener("load", function() {
+  if (document.body.clientWidth > 699) return;
+  document.querySelectorAll(".wwd-slide").forEach(slide => {
+    const container = slide.querySelector(".wwd-slide__img-container");
+    if (!container) return;
+    const line = slide.querySelector(".wwd-slide__list-line");
+    const arrow = slide.querySelector(".wwd-slide__list-arrow");
+    if (line) line.style.display = "none";
+    if (arrow) arrow.style.display = "none";
+    slide.querySelectorAll(".wwd-slide__list-item").forEach(item => {
+      const panel = container.querySelector(
+        `.wwd-slide__text[aria-labelledby=${item.id}]`
+      );
+      if (!panel) return;
+      panel.classList.remove("visible");
+      panel.style.maxHeight = null;
+      item.after(panel);
+      item.addEventListener("click", function(e) {
+        e.preventDefault();
+        this.classList.toggle("is-active");
+        panel.classList.toggle("visible");
+        if (panel.style.maxHeight) {
+          panel.style.maxHeight = null;
+        } else {
+          panel.style.maxHeight = panel.scrollHeight + "px";
+        }
+      });
+    });
+  });
+});

--- a/ru/index.html
+++ b/ru/index.html
@@ -12,6 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="description" />
     <link rel="stylesheet" href="../dist/style.min.css" />
+    <link rel="stylesheet" href="../css/wwd-mobile.css" />
   </head>
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-K7N9QCXLFH"></script>
@@ -2146,5 +2147,6 @@
                
     </div>
     <script type="module" src="../dist/all.min.js"></script>
+    <script type="module" src="../js/wwd-mobile.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- implement mobile accordion logic for "what we do" items on RU homepage
- add mobile-specific styles and script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a30979a55c832b926766a9bf2ef088