### PR TITLE
Ensure mobile slide panels toggle visibility on mobile

### DIFF
--- a/css/wwd-mobile.css
+++ b/css/wwd-mobile.css
@@ -18,8 +18,19 @@
     transform: translateY(-50%) rotate(-135deg);
   }
   .wwd-slide__text {
+    position: static;
+    left: auto;
+    top: auto;
+    width: 100%;
+    opacity: 0;
+    visibility: hidden;
     overflow: hidden;
     max-height: 0;
     transition: max-height 0.3s ease;
+  }
+
+  .wwd-slide__text.visible {
+    opacity: 1;
+    visibility: visible;
   }
 }


### PR DESCRIPTION
## Summary
- Enable visibility toggling for mobile slide text by defining hidden and visible states in `wwd-mobile.css`.
- Confirm `wwd-mobile.js` moves text panels beneath list items and toggles the `visible` class on click.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a30ee1cd88832bab46d9a1734139db