### PR TITLE
Add opacity transition for mobile slide text

### DIFF
--- a/css/wwd-mobile.css
+++ b/css/wwd-mobile.css
@@ -26,7 +26,7 @@
     visibility: hidden;
     overflow: hidden;
     max-height: 0;
-    transition: max-height 0.3s ease;
+    transition: max-height .3s ease, opacity .3s;
   }
 
   .wwd-slide__text.visible {


### PR DESCRIPTION
## Summary
- ensure mobile slide text fades and expands smoothly by adding opacity transition in `.wwd-slide__text`

## Testing
- `npx --yes stylelint css/wwd-mobile.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a311547bb0832ba42a2aa183e0e54e