### PR TITLE
Add services page with structuring, administration, and succession

### DIFF
--- a/ru/services.html
+++ b/ru/services.html
@@ -1,0 +1,628 @@
+<!DOCTYPE html>
+<html lang="ru" dir="ltr">
+  <head>
+    <link rel="icon" type="image/png" sizes="32x32" href="../icons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../icons/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../icons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="../icons/android-chrome-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="../icons/android-chrome-512x512.png">
+    <link rel="shortcut icon" href="../icons/favicon.ico">
+    <meta charset="utf-8" />
+    <title>ITSWM | Что мы делаем</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="description" />
+    <link rel="stylesheet" href="../dist/style.min.css" />
+  </head>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-K7N9QCXLFH"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-K7N9QCXLFH');
+</script>
+  <body class="base-scroll">
+    <header class="header">
+      <div class="wrap">
+        <a
+          href="."
+          class="header__link dark-theme"
+          data-theme-observer-margin="-9% 0% -91% 0%"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="100"
+            height="32.655"
+            viewBox="0 0 239.04 65.31"
+            fill="var(--gray-lightest)"
+          >
+            <path
+              d="M206.76,57.98c0.77-0.53,1.64-0.79,2.6-0.79c0.82,0,1.48,0.19,1.99,0.57c0.51,0.38,0.76,0.92,0.76,1.63
+              c0,0.59-0.19,1.09-0.58,1.51c-0.39,0.42-0.91,0.83-1.58,1.22c-0.05,0.03-0.15,0.09-0.29,0.17c-0.14,0.08-0.24,0.14-0.3,0.18
+              c-0.06,0.03-0.15,0.09-0.27,0.17c-0.12,0.08-0.21,0.13-0.27,0.17c-0.06,0.04-0.13,0.09-0.23,0.17c-0.1,0.07-0.17,0.13-0.21,0.18
+              c-0.05,0.05-0.1,0.11-0.16,0.18c-0.06,0.07-0.11,0.14-0.13,0.2c-0.03,0.06-0.05,0.13-0.07,0.21c-0.02,0.08-0.03,0.15-0.03,0.23
+              l4.19-0.01v1.18h-5.66v-0.6c0-0.43,0.06-0.81,0.18-1.14c0.12-0.33,0.33-0.64,0.63-0.92c0.3-0.28,0.54-0.48,0.71-0.6
+              c0.17-0.12,0.47-0.3,0.9-0.56c0.04-0.03,0.07-0.05,0.1-0.07c0.03-0.02,0.06-0.03,0.09-0.05c0.64-0.38,1.06-0.65,1.24-0.82
+              c0.31-0.3,0.46-0.63,0.46-1c0-0.34-0.14-0.59-0.41-0.77c-0.27-0.18-0.65-0.26-1.14-0.26c-0.85,0-1.68,0.29-2.48,0.87V57.98z
+               M216.46,64.18c-0.59-0.75-0.88-1.73-0.88-2.94c0-1.21,0.29-2.19,0.88-2.94c0.59-0.75,1.46-1.12,2.62-1.12
+              c1.16,0,2.03,0.37,2.62,1.12c0.59,0.75,0.88,1.73,0.88,2.94c0,1.21-0.29,2.19-0.88,2.94c-0.59,0.75-1.46,1.12-2.62,1.12
+              C217.92,65.3,217.05,64.93,216.46,64.18z M219.08,64.1c1.45,0,2.18-0.95,2.18-2.86c0-1.91-0.73-2.86-2.18-2.86
+              c-1.46,0-2.18,0.95-2.18,2.86C216.9,63.15,217.62,64.1,219.08,64.1z M226.03,58.06v1.21l1.56-0.59v5.28h-1.56v1.18h4.25v-1.18h-1.39
+              v-6.63h-0.96L226.03,58.06z M233.58,59.25c0.8-0.58,1.63-0.87,2.48-0.87c0.49,0,0.87,0.09,1.14,0.26c0.27,0.18,0.41,0.43,0.41,0.77
+              c0,0.37-0.15,0.7-0.46,1c-0.18,0.17-0.6,0.44-1.24,0.82c-0.03,0.02-0.06,0.03-0.09,0.05c-0.03,0.02-0.06,0.04-0.1,0.07
+              c-0.43,0.25-0.73,0.44-0.9,0.56c-0.17,0.12-0.4,0.32-0.71,0.6c-0.3,0.28-0.51,0.59-0.63,0.92c-0.12,0.33-0.18,0.71-0.18,1.14v0.6
+              h5.66v-1.18l-4.19,0.01c0-0.08,0.01-0.15,0.03-0.23c0.02-0.08,0.05-0.15,0.07-0.21c0.03-0.06,0.07-0.13,0.13-0.2
+              c0.06-0.07,0.11-0.13,0.16-0.18c0.05-0.05,0.12-0.11,0.21-0.18c0.1-0.07,0.17-0.13,0.23-0.17c0.06-0.04,0.15-0.1,0.27-0.17
+              c0.12-0.08,0.21-0.13,0.27-0.17c0.06-0.03,0.16-0.09,0.3-0.18c0.14-0.08,0.24-0.14,0.29-0.17c0.67-0.4,1.19-0.81,1.58-1.22
+              c0.39-0.42,0.58-0.92,0.58-1.51c0-0.7-0.25-1.25-0.76-1.63c-0.51-0.38-1.17-0.57-1.99-0.57c-0.96,0-1.82,0.26-2.6,0.79V59.25z
+               M157.12,60.32c0.23,0.32,0.51,0.56,0.85,0.73c0.34,0.16,0.71,0.32,1.11,0.47c0.4,0.15,0.77,0.28,1.11,0.38
+              c0.34,0.11,0.62,0.26,0.85,0.47c0.23,0.21,0.34,0.46,0.34,0.75c0,0.67-0.6,1-1.8,1c-1.02,0-1.94-0.26-2.76-0.79v1.29
+              c0.83,0.47,1.78,0.7,2.85,0.7c0.89,0.01,1.62-0.17,2.19-0.53c0.57-0.36,0.86-0.94,0.86-1.73c0-0.53-0.16-0.97-0.47-1.33
+              c-0.31-0.36-0.7-0.62-1.15-0.8c-0.45-0.18-0.9-0.33-1.36-0.47c-0.45-0.14-0.83-0.31-1.15-0.52c-0.31-0.21-0.47-0.47-0.47-0.79
+              c0-0.65,0.53-0.98,1.6-0.98c0.93-0.02,1.73,0.21,2.41,0.67v-1.25c-0.7-0.41-1.54-0.61-2.52-0.61c-0.8,0-1.48,0.19-2.02,0.57
+              c-0.54,0.38-0.81,0.92-0.81,1.63C156.78,59.61,156.89,59.99,157.12,60.32z M166.32,65.16h1.31v-8.04h-1.31V65.16z M173.19,60.16
+              c0-0.4,0-0.69-0.01-0.87l4.33,5.88h1.23v-8.04h-1.31v5c0,0.41,0,0.7,0.01,0.88l-4.33-5.88h-1.23v8.04h1.31V60.16z M182.86,63
+              c0.24,0.54,0.57,0.97,0.99,1.3c0.41,0.33,0.87,0.58,1.37,0.75c0.5,0.17,1.01,0.26,1.55,0.26c0.83,0,1.61-0.18,2.33-0.53v-1.3
+              c-0.54,0.41-1.24,0.62-2.1,0.62c-0.54,0-1.04-0.1-1.5-0.3c-0.47-0.2-0.86-0.52-1.18-0.98c-0.32-0.45-0.48-0.99-0.48-1.62
+              c0.01-1,0.32-1.75,0.94-2.26c0.62-0.51,1.36-0.77,2.21-0.77c0.8,0,1.49,0.2,2.07,0.6V57.5c-0.7-0.35-1.47-0.53-2.29-0.53
+              c-0.54,0-1.06,0.09-1.56,0.26c-0.5,0.18-0.95,0.43-1.36,0.78c-0.41,0.34-0.73,0.79-0.98,1.34c-0.25,0.55-0.37,1.17-0.37,1.86
+              C182.5,61.87,182.62,62.47,182.86,63z M192.81,65.16h5.61v-1.19h-4.3v-2.26H198v-1.19h-3.88v-2.19h4.23v-1.19h-5.54V65.16z
+               M239.04,44.32l-13.46-33.24l-8.31,21.37l-8.31-21.37L195.9,43.93h5.14l7.92-20.18l8.31,21.77l8.31-21.77l8.31,20.58H239.04z
+               M181.26,45.51l13.46-33.24h-5.14l-8.31,20.58l-8.31-21.77l-8.31,21.77l-7.92-20.18h-5.14l13.06,32.85l8.31-21.37L181.26,45.51z
+               M129.41,20.18c0.17-1.67,0.96-3.79,4.75-3.56c3.14-0.06,4.35,2.77,4.35,2.77l3.96-2.37c0,0-3.35-5.49-8.71-5.14
+              c-5.36,0.35-8.44,2.3-9.1,8.31c-0.08,9.18,13.95,7.44,13.85,14.64c-0.06,1.6-0.83,4.75-5.14,4.75c-5.06,0.08-5.54-5.54-5.54-5.54
+              l-4.75,0.79c0,0,0.93,9.22,10.29,9.5c1.5,0.07,9.51-1.44,9.89-9.89C144.34,24.53,129.04,25.14,129.41,20.18z M105.66,17.41h7.12
+              v-5.14h-7.12h-5.15H93.4v5.14h7.12v26.12h5.15V17.41z M74.4,43.53h5.15V12.27H74.4V43.53z M52.04,44.54c3-4.4,4.8-9.68,4.94-15.37
+              c-3.06,1.21-12.25,4.84-21.85,8.64L52.04,44.54z M35.33,18.89c9.67,3.76,18.85,7.33,21.63,8.42c-0.22-5.5-2.01-10.59-4.92-14.85
+              C50.57,13.02,43.33,15.81,35.33,18.89z M28.49,16.23c9.57-3.73,18.26-7.11,20.18-7.86C43.51,3.2,36.37,0,28.49,0
+              C20.61,0,13.47,3.2,8.32,8.37C10.24,9.12,18.92,12.5,28.49,16.23z M21.65,18.89c-8-3.08-15.24-5.87-16.72-6.44
+              c-2.91,4.26-4.69,9.36-4.92,14.85C2.81,26.22,11.98,22.66,21.65,18.89z M21.85,37.81c-9.6-3.8-18.79-7.43-21.85-8.64
+              c0.13,5.7,1.93,10.98,4.94,15.37L21.85,37.81z M11.08,28.23l17.41,6.93l17.41-6.93c-0.01-0.01-8.28-3.19-17.41-6.71
+              C19.36,25.04,11.09,28.22,11.08,28.23z M28.49,40.43C18.47,44.4,9.46,47.96,8.18,48.48c5.17,5.25,12.36,8.51,20.31,8.51
+              s15.14-3.26,20.31-8.51C47.51,47.96,38.5,44.39,28.49,40.43z"
+              transform="translate(0 0)"
+            />
+          </svg>
+        </a>
+        <div class="header__mobile-menu">
+          <button class="burger-menu" aria-label="open menu">
+            <span class="burger-menu__buns">
+              <span></span>
+              <span></span>
+              <span></span>
+              <span></span>
+            </span>
+          </button>
+        </div>
+        <!-- <div class="lang-switcher js-lang-switcher">
+          <a href="../pages/management.html" class="swith-to-lang">ENG</a>
+        </div> -->
+      </div>
+    </header>
+    <div class="menu">
+      <div class="menu__wrapper">
+        <div class="menu__block"></div>
+        <nav class="menu__navigation">
+          <ul class="menu__primary-list primary-list">
+            <li class="primary-list__item js-home-page-link">
+              <a class="menu__link menu__primary-link js-menu-primary-link">
+                <span class="link__arrow"></span>
+                Кто мы
+              </a>
+              <ul class="menu__secondary-list secondary-list">
+                <span class="menu__divider"></span>
+                <li class="secondary-list__item is-hovered">
+                  <ul class="menu__tertiary-list tertiary-list">
+                    <span class="menu__arrow"></span>
+                    <li class="tertiary-list__item">
+                      <a class="menu__link menu__tertiary-link" href="pages/portrait.html">
+                        Портрет
+                      </a>                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="pages/mission.html"
+                      >
+                        Миссия и ценности
+                      </a>
+                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="pages/benefits-principles.html"
+                      >
+                        Преимущества<br />
+                        и принципы работы
+                      </a>
+                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="expertise.html"
+                      >
+                        Экспертиза
+                      </a>
+                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="clients.html"
+                      >
+                        Клиенты
+                      </a>
+                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="pages/team.html"
+                      >
+                        Команда и партнеры
+                      </a>
+                    </li>
+                    <!--
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="pages/history.html"
+                      >
+                        История
+                      </a>
+                    </li>
+                    -->
+                  </ul>
+                </li>
+              </ul>
+            </li>
+
+            <li class="primary-list__item">
+              <a class="menu__link menu__primary-link js-menu-primary-link">
+                <span class="link__arrow link__arrow--active"></span>
+                Что мы делаем
+              </a>
+              <ul class="menu__secondary-list secondary-list menu__secondary-list--show">
+                <span class="menu__divider"></span>
+                <li class="secondary-list__item is-hovered">
+                  <a
+                    class="menu__link menu__secondary-link"
+                    href="formation-and-support.html"
+                  >
+                  Структурирование <br />
+                  
+                  </a>
+                  <ul class="menu__tertiary-list tertiary-list">
+                    <span class="menu__arrow"></span>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="formation-and-support.html#top"
+                      >
+                      Учреждение и сопровождение
+                      </a>
+                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="banking.html#top"
+                      >
+                      Банковские счета
+                      </a>
+                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="optimization.html#top"
+                      >
+                      Оптимизация структур
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+
+                <span class="menu__divider"></span>
+                <li class="secondary-list__item">
+                  <a
+                    class="menu__link menu__secondary-link"
+                    href="legal-support.html"
+                  >
+                  Администрирование <br />
+
+                  </a>
+                  <ul class="menu__tertiary-list tertiary-list">
+                    <span class="menu__arrow"></span>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="legal-support.html#top"
+                      >
+                      Юридическое сопровождение
+                      </a>
+                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="tax-support.html#top"
+                      >
+                      Налоговое сопровождение
+                      </a>
+                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="maintenance.html#top"
+                      >
+                      Обслуживание
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+
+                <span class="menu__divider"></span>
+                <li class="secondary-list__item">
+                  <a
+                    class="menu__link menu__secondary-link"
+                    href="pages/succession.html"
+                  >
+                    Преемственность<br />&nbsp;
+                  </a>
+                  <ul class="menu__tertiary-list tertiary-list">
+                    <span class="menu__arrow"></span>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="pages/succession.html#planning-family"
+                      >
+                        Планирование при<br />
+                        изменении состава семьи
+                      </a>
+                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="pages/succession.html#preparation-for-inheritance"
+                      >
+                        Подготовка<br />
+                        к наследованию
+                      </a>
+                    </li>
+                    <li class="tertiary-list__item">
+                      <a
+                        class="menu__link menu__tertiary-link"
+                        href="pages/succession.html#generation-involvement"
+                      >
+                        Образование и вовлечение<br />
+                        будущих поколений
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+
+            <li class="contacts primary-list__item js-contacts-link">
+              <a
+                class="menu__link menu__primary-link js-menu-primary-link"
+                href="contacts.html"
+              >
+                <span class="link__arrow"></span>
+                Контакты
+              </a>
+              <ul class="menu__secondary-list secondary-list">
+                <span class="menu__divider"></span>
+                <li class="contacts__menu-list secondary-list__item">
+                  <ul
+                    class="contacts__menu-locations menu__tertiary-list tertiary-list"
+                  >
+                  <!-- <li class="tertiary-list__item">
+                    Москва
+                    <br />
+                    1-ая Тверская-Ямская, 21
+                    <br />
+                    <a href="tel:+74957771987">+7 4957771987</a>
+                  </li> -->
+                  <li class="tertiary-list__item">
+                    Люксембург
+                    <br />
+                    Rue Henri Schnadt, 10A
+                    <br />
+                    <br />
+                    Написать нам:
+                    <br />
+                    <a href="mailto:europe@itswm.com"><u>europe@itswm.com</u></a>
+                  </li>
+                  <li class="tertiary-list__item">
+                    Дубай
+                    <br />
+                    The Offices 2, One Central, DWTC
+                    <br />
+                    <br />
+                    Написать нам:
+                    <br />
+                    <a href="mailto:uae@itswm.com"><u>uae@itswm.com</u></a>
+                  </li>
+
+                    <a
+                      href="contacts.html"
+                      class="contacts__map-btn button button--white"
+                    >
+                      Все контакты
+                    </a>
+                  </ul>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </nav>
+        <a
+          class="menu__link menu__quaternary-link"
+          href="terms.html"
+          style="text-decoration:none;border-bottom:1px dashed white;position:absolute;padding:0.25rem 0;bottom:1rem;right:1rem;text-transform:none"
+          >Правила пользования сайтом, ITSWM &copy;&nbsp;2025</a>
+      </div>
+    </div>
+      </div>
+    </div>
+    <div ss-container>
+      <aside
+        class="sidebar dark-theme"
+        data-theme-observer-margin="-90% 0% -10% 0%"
+      >
+        <nav class="side-nav sidebar__nav">
+          <a href="#key-section" class="side-nav__link" data-scroll>
+            Структурирование <br />активов
+          </a>
+          <a href="#administration" class="side-nav__link" data-scroll>
+            Администрирование <br />активов
+          </a>
+          <a href="#succession" class="side-nav__link" data-scroll>
+            Преемственность
+          </a>
+        </nav>
+        <a class="sidebar__up-link" href="#top" data-scroll>Вверх</a>
+      </aside>
+      <div class="page-banner" data-section data-theme="dark">
+        <img
+          class="page-banner__image"
+          src="../images/covers/invest-portfel.jpeg"
+          aria-hidden="true"
+          alt=""
+        />
+        <p
+          class="page-banner__text page-banner__text--invest"
+          aria-hidden="true"
+        >
+        Что мы делаем
+        </p>
+      </div>
+      <section
+        class="investp section"
+        id="top"
+        data-section
+        data-theme="light"
+        data-hidden-bar
+      >
+        <div class="investp__content col-xs-20 col-sm-16 col-lg-16">
+          <div class="investp__info-block">
+          <div class="investp__title visible-sm-up">
+              Одна система управления капиталом
+            </div>
+            <h2 class="section__subtitle">
+              Архитектура владения и ежедневная практика
+            </h2>
+            <p class="investp__desc section__desc">
+              Мы соединяем стратегию и ежедневную практику. На уровне стратегии — проектируем структуру владения и взаимосвязь активов и компаний в нужных юрисдикциях. На уровне практики — обеспечиваем дисциплину процессов: комплаенс, отчётность, взаимодействие с банками и провайдерами. Отдельная линия — подготовка к наследованию и управлению капиталом следующими поколениями.
+            </p>
+          </div>
+          <nav
+          class="investp__navigation investp__navigation--shift nav-circle js-nav-circle visible-sm-up"
+          id="navigation"
+        >
+          <div class="nav-circle__item" role="menuitem">
+            <a
+              href="#key-section"
+              class="nav-circle__item-icon visible-sm-up js-circle-letter"
+              aria-hidden="true"
+              tabindex="-1"
+              data-scroll
+            >
+              С.
+            </a>
+            <div class="nav-circle__item-text js-circle-text">
+              <a href="#key-section" data-scroll>
+                Структурирование <br />активов
+              </a>
+            </div>
+          </div>
+          <div class="nav-circle__item" role="menuitem">
+            <a
+              href="#administration"
+              class="nav-circle__item-icon visible-sm-up js-circle-letter"
+              aria-hidden="true"
+              tabindex="-1"
+              data-scroll
+            >
+              А.
+            </a>
+            <div class="nav-circle__item-text js-circle-text">
+              <a href="#administration" data-scroll>
+                Администрирование <br />активов
+              </a>
+            </div>
+          </div>
+          <div class="nav-circle__item" role="menuitem">
+            <a
+              href="#succession"
+              class="nav-circle__item-icon visible-sm-up js-circle-letter"
+              aria-hidden="true"
+              tabindex="-1"
+              data-scroll
+            >
+              П.
+            </a>
+            <div class="nav-circle__item-text js-circle-text">
+              <a href="#succession" data-scroll>
+                Преемственность
+              </a>
+            </div>
+          </div>
+        </nav>
+        </div>
+      </section>
+      <section
+        class="key-section key-section--management section"
+        id="key-section"
+        data-section
+        data-theme="dark"
+      >
+        <div class="key-section__main-left-side mob-arrow">
+          <span class="key-section__bg-letter" aria-hidden="true">С</span>
+          <div class="key-section__info">
+            <h1 class="key-section__target-text">
+              Структурирование активов
+            </h1>
+            <p class="key-section__desc section__desc">
+              Создаём и наводим порядок в структуре владения: под географию семьи, состав активов и планы на горизонте лет. Обеспечиваем юридическую, налоговую и операционную устойчивость решений и сразу выстраиваем банковскую инфраструктуру.
+            </p>
+            <p class="key-section__desc section__desc">
+              <b><a href="/ru/formation-and-support.html"><u>Учреждение и сопровождение структур.</u></a></b> Компании, трасты, семейные фонды; корпоративное управление и отчётность.
+            </p>
+            <p class="key-section__desc section__desc">
+              <b><a href="/ru/banking.html"><u>Банковские счета и инфраструктура.</u></a></b> Подготовка KYC‑пакета, сопровождение открытия, устойчивые отношения с банками.
+            </p>
+            <p class="key-section__desc section__desc">
+              <b><a href="/ru/optimization.html#key-section"><u>Оптимизация действующих структур.</u></a></b> Диагностика, устранение «узких мест», снижение рисков и издержек.
+            </p>
+          </div>
+        </div>
+        <div class="key-section__small-right-side">
+          <div class="key-section__img-container">
+            <img
+              class="key-section__image bot"
+              src="../images/invest-portfel/management1.jpeg"
+              alt=""
+              aria-hidden="true"
+            />
+          </div>
+        </div>
+      </section>
+      <section
+        class="section-1-3 section-1-3--management section"
+        id="administration"
+        data-section
+        data-theme="dark"
+      >
+        <img
+          class="section-1-3__image"
+          src="../images/invest-portfel/management2.jpeg"
+          alt=""
+          aria-hidden="true"
+        />
+        <div class="section-1-3__info">
+          <h3 class="section-1-3__title section__subtitle">
+            Администрирование активов
+            <span class="section__sub-bg-letter" aria-hidden="true">А</span>
+          </h3>
+          <p class="section__desc">
+            Ежедневная надёжность и контроль. Берём на себя юридическую и налоговую поддержку, координируем банки и провайдеров, готовим консолидированную отчётность по портфелю и администрируем отдельные классы активов — от недвижимости до коллекций, авиации и яхт.
+          </p>
+          <p class="section__desc">
+            <b><a href="/ru/legal-support.html"><u>Юридическое сопровождение.</u></a></b> Сделки, договоры, корпоративные действия, миграционные вопросы, споры.
+          </p>
+          <p class="section__desc">
+            <b><a href="/ru/tax-support.html#key-section"><u>Налоговое сопровождение.</u></a></b> Планирование и отчётность в разных странах, проверки, соглашения об избежании двойного налогообложения, валютное законодательство.
+          </p>
+          <p class="section__desc">
+            <b><a href="/ru/maintenance.html#key-section"><u>Обслуживание.</u></a></b> Координация провайдеров и банков, мониторинг и отчётность, администрирование активов.
+          </p>
+        </div>
+      </section>
+      <!-- <section
+        class="fullscreen fullscreen--assets section"
+        data-section
+        data-theme="dark"
+      >
+        <span
+          class="alfa-text alfa-text--white alfa-20 f-450"
+          aria-hidden="true"
+        >
+          Assets
+        </span>
+        <div class="grid">
+          <div class="grid__row">
+            <div
+              class="fullscreen__info col-sm-offset-12 col-sm-9 col-md-offset-13 col-md-8"
+            >
+              <h3 class="section__subtitle">
+                КОНСУЛЬТАЦИИ И ВОЗМОЖНОСТЬ ДЕЛЕГИРОВАНИЯ
+              </h3>
+              <p class="section__desc">
+                Для нас нет незначительных задач или, наоборот, слишком сложных проектов. 
+                Сотрудничество с ITSWM — это возможность получить экспертную поддержку и
+                сопровождение при решении задач, так и делегировать решение отдельных задач нашей команде.
+
+              </p>
+            </div>
+          </div>
+        </div>
+      </section> -->
+      <section class="all-services section" id="succession" data-section data-theme="light">
+        <div class="grid">
+          <div class="grid__row">
+            <div
+              class="all-services__info col-sm-offset-3 col-sm-10 col-md-offset-4 col-md-9 col-lg-offset-5 col-lg-6"
+            >
+              <h3 class="section__subtitle">
+                Преемственность
+                <span class="section__sub-bg-letter" aria-hidden="true">П</span>
+              </h3>
+              <div class="all-services__desc section__desc">
+                <span class="visible-sm-up">
+                  Помогаем сохранить и передать капитал по правилам семьи. Формируем семейно‑правовые договорённости, проектируем структуру наследования с учётом юрисдикций и вовлекаем следующее поколение: семейные советы, «сухие репетиции» решений, наставничество.
+                </span>
+                <p><b><a href="/ru/pages/succession.html"><u>Подробнее о преемственности</u></a></b></p>
+              </div>
+            </div>
+            <div
+              class="all-services__img-container visible-sm-up col-sm-offset-2 col-sm-9 col-md-offset-3 col-md-8 col-lg-7"
+            >
+              <img src="../images/invest-portfel/management4.jpeg" />
+            </div>
+            <span
+              class="all-services__color-line col-lg-3 visible-lg-up"
+            ></span>
+          </div>
+        </div>
+      </section>
+    </div>
+    <script type="module" src="../dist/all.min.js"></script>
+    <script>
+      // Функция для плавной прокрутки
+      function smoothScrollToElement(elementId) {
+        const target = document.getElementById(elementId);
+        if (target) {
+          target.scrollIntoView({ behavior: "smooth" });
+        }
+      }
+
+      // Плавная прокрутка при клике на ссылки с атрибутом data-scroll
+      document.querySelectorAll('a[data-scroll]').forEach((link) => {
+        link.addEventListener('click', (e) => {
+          e.preventDefault();
+          const elementId = link.getAttribute('href').substring(1);
+          smoothScrollToElement(elementId);
+        });
+      });
+
+      // Проверяем, есть ли якорь в URL после загрузки страницы
+      window.addEventListener('load', () => {
+        const urlHash = window.location.hash;
+        if (urlHash) {
+          const elementId = urlHash.substring(1); // Убираем '#' из якоря
+          setTimeout(() => {
+            smoothScrollToElement(elementId);
+          }, 0); // Можно увеличить задержку, если нужно больше времени для загрузки страницы
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Refine services page with concise heading and section navigation
- Convert item headings into links with plain descriptions and add background letters for all sections
- Implement smooth scrolling for side and top navigation links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a31c4961ac832b8ed3134f6d214232